### PR TITLE
Fixed gitignore file (should now ignore the Sqlite databases)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,6 @@ paket-files/
 
 # Mac OS chaff
 .DS_Store
+
+# Sqlite databases
+*.db


### PR DESCRIPTION
Sqlite databases should now be ignored in all commits from this point onwards