### PR TITLE
Fix/issue 16 template doesn't build

### DIFF
--- a/NuGetReadme.md
+++ b/NuGetReadme.md
@@ -1,3 +1,5 @@
+# Introduction
+
 OnionArch.Mvc is an ASP.NET Core project template which uses the onion architecture and domain driven design to scaffold an ASP.NET Core MVC application using feature folders.
 
 ## Installation

--- a/Onion.Web/Startup.cs
+++ b/Onion.Web/Startup.cs
@@ -2,13 +2,13 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-#if(enable-gnu-pratchett)
-using ClacksMiddleware;
-#endif
-#if(enable-secure-headers)
+//#if(enable-gnu-pratchett)
+using ClacksMiddleware.Extensions;
+//#endif
+//#if(enable-secure-headers)
 using OwaspHeaders.Core.Enums;
 using OwaspHeaders.Core.Extensions;
-#endif
+//#endif
 
 namespace Onion.Web
 {
@@ -48,12 +48,12 @@ namespace Onion.Web
                 app.UseExceptionHandler("/Home/Error");
             }
 
-#if(enable-gnu-pratchett)
+//#if(enable-gnu-pratchett)
             app.GnuTerryPratchett();
-#endif
-#if(enable-secure-headers)
+//#endif
+//#if(enable-secure-headers)
             app.UseSecureHeadersMiddleware(SecureHeadersMiddlewareExtensions.BuildDefaultConfiguration());
-#endif
+//#endif
 
             app.UseStaticFiles();
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ OnionArch has a Code of Conduct which all contributors, maintainers and forkers 
 
 See [Code of Conduct.md](Code-of-Conduct.md) for details.
 
+## Installing the Template
+
+To use the template locally, it will need to be installed. You can do this from either the NuGet package (see the next section) or by installing it from source. To install from source, please seen the [NuGetReadMe.md](NuGetReadme) file for instructions.
+
 ## NuGet Package
 
 This project is now available as a [NuGet package](https://www.nuget.org/packages/OnionArch.Mvc)


### PR DESCRIPTION
This pull request fixes #16  

### Summary of changes

#### Template Syntax

The template conditional syntax is now correct. The following is a copy of line 5 of Startup.cs:

``` csharp
//#if(enable-gnu-pratchett)
```

#### Readme

As a bonus, I have included a new section in the readme which details the steps required to install the template locally.